### PR TITLE
BinderContext lifetime adjusted to allow better concurrency Previously was DI Scoped (not transient) to allow an instance to be shared across binders, but this caused issues when multi-threading etc. whereby model instances could be shared across validation runs.

### DIFF
--- a/Xbim.IDS.Validator.Common/Interfaces/IBinderContext.cs
+++ b/Xbim.IDS.Validator.Common/Interfaces/IBinderContext.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xbim.Common;
+
+namespace Xbim.IDS.Validator.Core.Interfaces
+{
+    /// <summary>
+    /// Represents context used by a binder to access a model
+    /// </summary>
+    public interface IBinderContext
+    {
+        /// <summary>
+        /// Gets the model being validated
+        /// </summary>
+        IModel? Model { get; }
+    }
+}

--- a/Xbim.IDS.Validator.Common/Interfaces/IFacetBinder.cs
+++ b/Xbim.IDS.Validator.Common/Interfaces/IFacetBinder.cs
@@ -10,6 +10,11 @@ namespace Xbim.IDS.Validator.Core.Interfaces
     /// </summary>
     public interface IFacetBinder
     {
+        /// <summary>
+        /// Initialise the FacetBinder
+        /// </summary>
+        /// <param name="context"></param>
+        void Initialise(IBinderContext context);
 
         /// <summary>
         /// Binds the appropriate model filters to satisify the initial <paramref name="facet"/>'s criteria

--- a/Xbim.IDS.Validator.Common/Interfaces/IIdsFacetBinderFactory.cs
+++ b/Xbim.IDS.Validator.Common/Interfaces/IIdsFacetBinderFactory.cs
@@ -12,16 +12,18 @@ namespace Xbim.IDS.Validator.Core.Interfaces
         /// Create the appropriate FacetBinder for the Facet
         /// </summary>
         /// <param name="facet">A <see cref="IFacet"/></param>
+        /// <param name="context">The Binder context</param>
         /// <param name="schema">The target Schema</param>
         /// <returns></returns>
-        IFacetBinder Create(IFacet facet, XbimSchemaVersion schema = XbimSchemaVersion.Ifc2X3);
+        IFacetBinder Create(IFacet facet,  IBinderContext context, XbimSchemaVersion schema = XbimSchemaVersion.Ifc2X3);
         /// <summary>
         /// Generic method to create the appropriate FacetBinder for the Facet
         /// </summary>
         /// <typeparam name="TFacet"></typeparam>
         /// <param name="facet">A <see cref="IFacet"/></param>
+        /// <param name="context">The Binder context</param>
         /// <param name="schema">The target Schema</param>
         /// <returns></returns>
-        IFacetBinder<TFacet> Create<TFacet>(TFacet facet, XbimSchemaVersion schema = XbimSchemaVersion.Ifc2X3) where TFacet : IFacet;
+        IFacetBinder<TFacet> Create<TFacet>(TFacet facet, IBinderContext context, XbimSchemaVersion schema = XbimSchemaVersion.Ifc2X3) where TFacet : IFacet;
     }
 }

--- a/Xbim.IDS.Validator.Core.Tests/Binders/AttributeFacetBinderTests.cs
+++ b/Xbim.IDS.Validator.Core.Tests/Binders/AttributeFacetBinderTests.cs
@@ -14,7 +14,8 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
     {
         public AttributeFacetBinderTests(ITestOutputHelper output) : base(output)
         {
-            Binder = new AttributeFacetBinder(BinderContext, Logger, GetValueMapper());
+            Binder = new AttributeFacetBinder(Logger, GetValueMapper());
+            Binder.Initialise(BinderContext);
         }
 
         /// <summary>
@@ -95,8 +96,8 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
                 AttributeName = attributeFieldName,
                 AttributeValue = new ValueConstraint("not relevant")
             };
-            var ifcBinder = new IfcTypeFacetBinder(new BinderContext { Model = Model}, GetLogger<IfcTypeFacetBinder>());
-
+            var ifcBinder = new IfcTypeFacetBinder(GetLogger<IfcTypeFacetBinder>());
+            ifcBinder.Initialise(BinderContext);
 
             var expression = ifcBinder.BindSelectionExpression(query.InstancesExpression, ifcFacet);
             // Act

--- a/Xbim.IDS.Validator.Core.Tests/Binders/CombinedFacetBinderTests.cs
+++ b/Xbim.IDS.Validator.Core.Tests/Binders/CombinedFacetBinderTests.cs
@@ -34,9 +34,11 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
                 AttributeValue = new ValueConstraint(attributeValue)
             };
   
-            var ifcbinder = new IfcTypeFacetBinder(BinderContext, IfcTypeLogger);
+            var ifcbinder = new IfcTypeFacetBinder(IfcTypeLogger);
+            ifcbinder.Initialise(BinderContext);
 
-            var attrbinder = new AttributeFacetBinder(BinderContext, GetLogger<AttributeFacetBinder>(), GetValueMapper());
+            var attrbinder = new AttributeFacetBinder(GetLogger<AttributeFacetBinder>(), GetValueMapper());
+            attrbinder.Initialise(BinderContext);
 
             // Act
             var expression = ifcbinder.BindSelectionExpression(query.InstancesExpression, ifcFacet);
@@ -70,9 +72,11 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
             attrFacet.AttributeValue.AddAccepted(new StructureConstraint() { MinLength = 1, MaxLength = 10 });
 
    
-            var ifcbinder = new IfcTypeFacetBinder(BinderContext, IfcTypeLogger);
+            var ifcbinder = new IfcTypeFacetBinder(IfcTypeLogger);
+            ifcbinder.Initialise(BinderContext);
 
-            var attrbinder = new AttributeFacetBinder(BinderContext, GetLogger<AttributeFacetBinder>(), GetValueMapper());
+            var attrbinder = new AttributeFacetBinder(GetLogger<AttributeFacetBinder>(), GetValueMapper());
+            attrbinder.Initialise(BinderContext);
 
             // Act
             var expression = ifcbinder.BindSelectionExpression(query.InstancesExpression, ifcFacet);
@@ -112,10 +116,10 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
             {
                 classFacet.Identification = new ValueConstraint(ident);
             }
-            var ifcbinder = new IfcTypeFacetBinder(BinderContext, IfcTypeLogger);
-
-            var classbinder = new IfcClassificationFacetBinder(BinderContext, GetLogger<IfcClassificationFacetBinder>());
-
+            var ifcbinder = new IfcTypeFacetBinder(IfcTypeLogger);
+            ifcbinder.Initialise(BinderContext);
+            var classbinder = new IfcClassificationFacetBinder(GetLogger<IfcClassificationFacetBinder>());
+            classbinder.Initialise(BinderContext);
             // Act
             var expression = ifcbinder.BindSelectionExpression(query.InstancesExpression, ifcFacet);
             expression = classbinder.BindWhereExpression(expression, classFacet);
@@ -152,10 +156,10 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
                 Value = new ValueConstraint(),
             };
             materialFacet.Value = material;
-            var ifcbinder = new IfcTypeFacetBinder(BinderContext, IfcTypeLogger);
-
-            var materialbinder = new MaterialFacetBinder(BinderContext, GetLogger<MaterialFacetBinder>());
-
+            var ifcbinder = new IfcTypeFacetBinder(IfcTypeLogger);
+            ifcbinder.Initialise(BinderContext);
+            var materialbinder = new MaterialFacetBinder(GetLogger<MaterialFacetBinder>());
+            materialbinder.Initialise(BinderContext);
             // Act
             var expression = ifcbinder.BindSelectionExpression(query.InstancesExpression, ifcFacet);
             expression = materialbinder.BindWhereExpression(expression, materialFacet);
@@ -192,9 +196,11 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
             propertyFacet.PropertyName.AddAccepted(new ExactConstraint(propName));
             if(value != null)
                 propertyFacet.PropertyValue.AddAccepted(new ExactConstraint(value?.ToString()));
-            var ifcbinder = new IfcTypeFacetBinder(BinderContext, IfcTypeLogger);
+            var ifcbinder = new IfcTypeFacetBinder(IfcTypeLogger);
+            ifcbinder.Initialise(BinderContext);
 
-            var psetbinder = new PsetFacetBinder(BinderContext, GetLogger<PsetFacetBinder>());
+            var psetbinder = new PsetFacetBinder(GetLogger<PsetFacetBinder>());
+            psetbinder.Initialise(BinderContext);
 
             // Act
             var expression = ifcbinder.BindSelectionExpression(query.InstancesExpression, ifcFacet);
@@ -224,8 +230,10 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
                 DataType = "IFCLABEL"
             };
 
-            var ifcbinder = new IfcTypeFacetBinder(BinderContext, IfcTypeLogger);
-            var psetbinder = new PsetFacetBinder(BinderContext, GetLogger<PsetFacetBinder>());
+            var ifcbinder = new IfcTypeFacetBinder(IfcTypeLogger);
+            ifcbinder.Initialise(BinderContext);
+            var psetbinder = new PsetFacetBinder(GetLogger<PsetFacetBinder>());
+            psetbinder.Initialise(BinderContext);
 
             // Act
             var expression = ifcbinder.BindSelectionExpression(query.InstancesExpression, ifcFacet);
@@ -255,10 +263,11 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
             partOfFacet.SetRelation(partOfRelation);
             
             
-            var ifcbinder = new IfcTypeFacetBinder(BinderContext, IfcTypeLogger);
+            var ifcbinder = new IfcTypeFacetBinder(IfcTypeLogger);
+            ifcbinder.Initialise(BinderContext);
 
-            var partOfbinder = new PartOfFacetBinder(BinderContext, GetLogger<PartOfFacetBinder>());
-
+            var partOfbinder = new PartOfFacetBinder(GetLogger<PartOfFacetBinder>());
+            partOfbinder.Initialise(BinderContext);
             // Act
             var expression = ifcbinder.BindSelectionExpression(query.InstancesExpression, ifcFacet);
             expression = partOfbinder.BindWhereExpression(expression, partOfFacet);

--- a/Xbim.IDS.Validator.Core.Tests/Binders/Ifc2x3BinderTests.cs
+++ b/Xbim.IDS.Validator.Core.Tests/Binders/Ifc2x3BinderTests.cs
@@ -37,10 +37,10 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
                 AttributeName = attributeFieldName,
                 AttributeValue = new ValueConstraint(attributeValue)
             };
-            var ifcbinder = new IfcTypeFacetBinder(BinderContext, GetLogger<IfcTypeFacetBinder>());
-
-            var attrbinder = new AttributeFacetBinder(BinderContext, GetLogger<AttributeFacetBinder>(), GetValueMapper());
-
+            var ifcbinder = new IfcTypeFacetBinder(GetLogger<IfcTypeFacetBinder>());
+            ifcbinder.Initialise(BinderContext);
+            var attrbinder = new AttributeFacetBinder(GetLogger<AttributeFacetBinder>(), GetValueMapper());
+            attrbinder.Initialise(BinderContext);
             // Act
             var expression = ifcbinder.BindSelectionExpression(query.InstancesExpression, ifcFacet);
             expression = attrbinder.BindWhereExpression(expression, attrFacet);
@@ -75,10 +75,10 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
             propertyFacet.PropertyName.AddAccepted(new ExactConstraint(propName));
             if (value != null)
                 propertyFacet.PropertyValue.AddAccepted(new ExactConstraint(value?.ToString()));
-            var ifcbinder = new IfcTypeFacetBinder(BinderContext, GetLogger<IfcTypeFacetBinder>());
-
-            var psetbinder = new PsetFacetBinder(BinderContext, GetLogger<PsetFacetBinder>());
-
+            var ifcbinder = new IfcTypeFacetBinder(GetLogger<IfcTypeFacetBinder>());
+            ifcbinder.Initialise(BinderContext);
+            var psetbinder = new PsetFacetBinder(GetLogger<PsetFacetBinder>());
+            psetbinder.Initialise(BinderContext);
             // Act
             var expression = ifcbinder.BindSelectionExpression(query.InstancesExpression, ifcFacet);
             expression = psetbinder.BindWhereExpression(expression, propertyFacet);
@@ -123,9 +123,10 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
             if (value2 != null)
                 propertyFacet2.PropertyValue.AddAccepted(new ExactConstraint(value2?.ToString()));
 
-            var psetbinder = new PsetFacetBinder(BinderContext, GetLogger<PsetFacetBinder>());
-            var psetbinder2 = new PsetFacetBinder(BinderContext, GetLogger<PsetFacetBinder>());
-
+            var psetbinder = new PsetFacetBinder(GetLogger<PsetFacetBinder>());
+            psetbinder.Initialise(BinderContext);
+            var psetbinder2 = new PsetFacetBinder(GetLogger<PsetFacetBinder>());
+            psetbinder2.Initialise(BinderContext);
             // Act
             var expression = psetbinder.BindSelectionExpression(query.InstancesExpression, propertyFacet);
             expression = psetbinder2.BindWhereExpression(expression, propertyFacet2);
@@ -154,10 +155,10 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
                 Value = new ValueConstraint(),
             };
             materialFacet.Value = material;
-            var ifcbinder = new IfcTypeFacetBinder(BinderContext, GetLogger<IfcTypeFacetBinder>());
-
-            var materialbinder = new MaterialFacetBinder(BinderContext, GetLogger<MaterialFacetBinder>());
-
+            var ifcbinder = new IfcTypeFacetBinder( GetLogger<IfcTypeFacetBinder>());
+            ifcbinder.Initialise(BinderContext);
+            var materialbinder = new MaterialFacetBinder(GetLogger<MaterialFacetBinder>());
+            materialbinder.Initialise(BinderContext);
             // Act
             var expression = ifcbinder.BindSelectionExpression(query.InstancesExpression, ifcFacet);
             expression = materialbinder.BindWhereExpression(expression, materialFacet);
@@ -179,7 +180,8 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
            ConstraintType valueConstraint = ConstraintType.Exact
            )
         {
-            var psetbinder = new PsetFacetBinder(BinderContext, GetLogger<PsetFacetBinder>());
+            var psetbinder = new PsetFacetBinder(GetLogger<PsetFacetBinder>());
+            psetbinder.Initialise(BinderContext);
             AssertIfcPropertyFacetQuery(psetbinder, psetName, propName, propValue, expectedCount, psetConstraint, propConstraint, valueConstraint);
 
         }

--- a/Xbim.IDS.Validator.Core.Tests/Binders/IfcClassificationFacetBinderTests.cs
+++ b/Xbim.IDS.Validator.Core.Tests/Binders/IfcClassificationFacetBinderTests.cs
@@ -12,7 +12,8 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
     {
         public IfcClassificationFacetBinderTests(ITestOutputHelper output) : base(output)
         {
-            Binder = new IfcClassificationFacetBinder(BinderContext, GetLogger<IfcClassificationFacetBinder>());
+            Binder = new IfcClassificationFacetBinder(GetLogger<IfcClassificationFacetBinder>());
+            Binder.Initialise(BinderContext);
         }
 
         /// <summary>

--- a/Xbim.IDS.Validator.Core.Tests/Binders/IfcTypeFacetBinder2x3Tests.cs
+++ b/Xbim.IDS.Validator.Core.Tests/Binders/IfcTypeFacetBinder2x3Tests.cs
@@ -11,7 +11,8 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
     {
         public IfcTypeFacetBinder2x3Tests(ITestOutputHelper output) : base(output, Xbim.Common.Step21.XbimSchemaVersion.Ifc2X3)
         {
-            Binder = new IfcTypeFacetBinder(BinderContext, GetLogger<IfcTypeFacetBinder>());
+            Binder = new IfcTypeFacetBinder(GetLogger<IfcTypeFacetBinder>());
+            Binder.Initialise(BinderContext);
         }
 
         /// <summary>

--- a/Xbim.IDS.Validator.Core.Tests/Binders/IfcTypeFacetBinderTests.cs
+++ b/Xbim.IDS.Validator.Core.Tests/Binders/IfcTypeFacetBinderTests.cs
@@ -11,7 +11,8 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
     {
         public IfcTypeFacetBinderTests(ITestOutputHelper output) : base(output)
         {
-            Binder = new IfcTypeFacetBinder(BinderContext, GetLogger<IfcTypeFacetBinder>());
+            Binder = new IfcTypeFacetBinder(GetLogger<IfcTypeFacetBinder>());
+            Binder.Initialise(BinderContext);
         }
 
         /// <summary>

--- a/Xbim.IDS.Validator.Core.Tests/Binders/MaterialBinderTests.cs
+++ b/Xbim.IDS.Validator.Core.Tests/Binders/MaterialBinderTests.cs
@@ -12,7 +12,8 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
     {
         public MaterialBinderTests(ITestOutputHelper output) : base(output)
         {
-            Binder = new MaterialFacetBinder(BinderContext, GetLogger<MaterialFacetBinder>());
+            Binder = new MaterialFacetBinder(GetLogger<MaterialFacetBinder>());
+            Binder.Initialise(BinderContext);
         }
 
         /// <summary>

--- a/Xbim.IDS.Validator.Core.Tests/Binders/PartOfBinderTests.cs
+++ b/Xbim.IDS.Validator.Core.Tests/Binders/PartOfBinderTests.cs
@@ -13,7 +13,8 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
     {
         public PartOfBinderTests(ITestOutputHelper output) : base(output)
         {
-            Binder = new PartOfFacetBinder(BinderContext, Logger);
+            Binder = new PartOfFacetBinder(Logger);
+            Binder.Initialise(BinderContext);
         }
 
         /// <summary>

--- a/Xbim.IDS.Validator.Core.Tests/Binders/PsetFacetBinderTests.cs
+++ b/Xbim.IDS.Validator.Core.Tests/Binders/PsetFacetBinderTests.cs
@@ -12,7 +12,8 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
 
         public PsetFacetBinderTests(ITestOutputHelper output) : base(output)
         {
-            Binder = new PsetFacetBinder(BinderContext, Logger);
+            Binder = new PsetFacetBinder(Logger);
+            Binder.Initialise(BinderContext);
         }
 
         /// <summary>

--- a/Xbim.IDS.Validator.Core.Tests/ServicesTests.cs
+++ b/Xbim.IDS.Validator.Core.Tests/ServicesTests.cs
@@ -38,8 +38,9 @@ namespace Xbim.IDS.Validator.Core.Tests
             // Arrange
             var factory = provider.GetRequiredService<IIdsFacetBinderFactory>();
             var facet = (IFacet)Activator.CreateInstance(facetType);
+            var context = new BinderContext();
             // Act
-            var result = factory.Create(facet);
+            var result = factory.Create(facet, context);
             result.Should().NotBeNull().And.BeOfType(expectedType);
         }
 

--- a/Xbim.IDS.Validator.Core/Binders/AttributeFacetBinder.cs
+++ b/Xbim.IDS.Validator.Core/Binders/AttributeFacetBinder.cs
@@ -26,7 +26,7 @@ namespace Xbim.IDS.Validator.Core.Binders
         protected readonly IValueMapper valueMapper;
         private VerificationOptions _options = new VerificationOptions();
 
-        public AttributeFacetBinder(BinderContext context, ILogger<AttributeFacetBinder> logger, IValueMapper valueMapper) : base(context, logger)
+        public AttributeFacetBinder(ILogger<AttributeFacetBinder> logger, IValueMapper valueMapper) : base(logger)
         {
             this.logger = logger;
             this.valueMapper = valueMapper;

--- a/Xbim.IDS.Validator.Core/Binders/BinderContext.cs
+++ b/Xbim.IDS.Validator.Core/Binders/BinderContext.cs
@@ -1,8 +1,9 @@
 ﻿using Xbim.Common;
+using Xbim.IDS.Validator.Core.Interfaces;
 
 namespace Xbim.IDS.Validator.Core.Binders
 {
-    public class BinderContext
+    public class BinderContext: IBinderContext
     {
         /// <summary>
         /// The current model

--- a/Xbim.IDS.Validator.Core/Binders/FacetBinderBase.cs
+++ b/Xbim.IDS.Validator.Core/Binders/FacetBinderBase.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using Xbim.Common;
@@ -30,20 +29,27 @@ namespace Xbim.IDS.Validator.Core.Binders
         /// <summary>
         /// Constructs a new <see cref="FacetBinderBase{T}"/>
         /// </summary>
-        /// <param name="binderContext"></param>
         /// <param name="logger"></param>
-        public FacetBinderBase(BinderContext binderContext, ILogger<FacetBinderBase<T>> logger)
+        public FacetBinderBase(ILogger<FacetBinderBase<T>> logger)
         {
-            BinderContext = binderContext ?? throw new ArgumentNullException(nameof(binderContext));
             this.logger = logger;
         }
 
-        public BinderContext BinderContext { get; }
+        /// <summary>
+        /// Initialise the Binder with the model context
+        /// </summary>
+        /// <param name="context"></param>
+        public void Initialise(IBinderContext context)
+        {
+            BinderContext = context;
+        }
+
+        public IBinderContext? BinderContext { get; private set; }
 
         /// <summary>
         /// The model being queried
         /// </summary>
-        public IModel Model { get => BinderContext.Model ?? throw new ArgumentNullException(); }
+        public IModel Model { get => BinderContext?.Model ?? throw new InvalidOperationException("Incorrectly Initialised"); }
 
         /// <summary>
         /// Applies a Selection and Filter predicate to the supplied <paramref name="baseExpression"/> from the <paramref name="facet"/>

--- a/Xbim.IDS.Validator.Core/Binders/IfcClassificationFacetBinder.cs
+++ b/Xbim.IDS.Validator.Core/Binders/IfcClassificationFacetBinder.cs
@@ -18,7 +18,7 @@ namespace Xbim.IDS.Validator.Core.Binders
     {
         private readonly ILogger<IfcClassificationFacetBinder> logger;
 
-        public IfcClassificationFacetBinder(BinderContext context, ILogger<IfcClassificationFacetBinder> logger) : base(context, logger)
+        public IfcClassificationFacetBinder(ILogger<IfcClassificationFacetBinder> logger) : base(logger)
         {
             this.logger = logger;
         }

--- a/Xbim.IDS.Validator.Core/Binders/IfcTypeFacetBinder.cs
+++ b/Xbim.IDS.Validator.Core/Binders/IfcTypeFacetBinder.cs
@@ -18,7 +18,7 @@ namespace Xbim.IDS.Validator.Core.Binders
     {
         private readonly ILogger<IfcTypeFacetBinder> logger;
 
-        public IfcTypeFacetBinder(BinderContext binderContext, ILogger<IfcTypeFacetBinder> logger) : base(binderContext, logger)
+        public IfcTypeFacetBinder(ILogger<IfcTypeFacetBinder> logger) : base(logger)
         {
             this.logger = logger;
         }

--- a/Xbim.IDS.Validator.Core/Binders/MaterialFacetBinder.cs
+++ b/Xbim.IDS.Validator.Core/Binders/MaterialFacetBinder.cs
@@ -16,7 +16,7 @@ namespace Xbim.IDS.Validator.Core.Binders
     {
         private readonly ILogger<MaterialFacetBinder> logger;
 
-        public MaterialFacetBinder(BinderContext context, ILogger<MaterialFacetBinder> logger) : base(context, logger)
+        public MaterialFacetBinder(ILogger<MaterialFacetBinder> logger) : base(logger)
         {
             this.logger = logger;
         }

--- a/Xbim.IDS.Validator.Core/Binders/NotSupportedBinder.cs
+++ b/Xbim.IDS.Validator.Core/Binders/NotSupportedBinder.cs
@@ -15,7 +15,7 @@ namespace Xbim.IDS.Validator.Core.Binders
     {
         private readonly ILogger<FacetBinderBase<TFacet>> logger;
 
-        public NotSupportedBinder(BinderContext binderContext, ILogger<NotSupportedBinder<TFacet>> logger) : base(binderContext, logger)
+        public NotSupportedBinder(ILogger<NotSupportedBinder<TFacet>> logger) : base(logger)
         {
             this.logger = logger;
         }

--- a/Xbim.IDS.Validator.Core/Binders/PartOfFacetBinder.cs
+++ b/Xbim.IDS.Validator.Core/Binders/PartOfFacetBinder.cs
@@ -16,7 +16,7 @@ namespace Xbim.IDS.Validator.Core.Binders
     {
         private readonly ILogger<PartOfFacetBinder> logger;
 
-        public PartOfFacetBinder(BinderContext binderContext, ILogger<PartOfFacetBinder> logger) : base(binderContext, logger)
+        public PartOfFacetBinder(ILogger<PartOfFacetBinder> logger) : base(logger)
         {
             this.logger = logger;
         }

--- a/Xbim.IDS.Validator.Core/Binders/PsetFacetBinder.cs
+++ b/Xbim.IDS.Validator.Core/Binders/PsetFacetBinder.cs
@@ -23,7 +23,7 @@ namespace Xbim.IDS.Validator.Core.Binders
     {
         private readonly ILogger<PsetFacetBinder> logger;
 
-        public PsetFacetBinder(BinderContext context, ILogger<PsetFacetBinder> logger) : base(context, logger)
+        public PsetFacetBinder(ILogger<PsetFacetBinder> logger) : base(logger)
         {
             this.logger = logger;
         }

--- a/Xbim.IDS.Validator.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/Xbim.IDS.Validator.Core/Extensions/ServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ namespace Xbim.IDS.Validator.Core
             services.AddTransient<IIdsModelValidator, IdsModelValidator>();
             services.AddTransient<IIdsValidator, IdsValidator>();
             services.AddTransient<IIdsSchemaMigrator, IdsSchemaMigrator>();
-            services.AddScoped<BinderContext>();
+            
             services.AddSingleton<IIdsFacetBinderFactory, IdsFacetBinderFactory>();
             services.AddSingleton<IValueMapper, IdsValueMapper>();
             services.AddSingleton<IValueMapProvider, IdsValueMapProvider>();

--- a/Xbim.IDS.Validator.Core/IdsFacetBinderFactory.cs
+++ b/Xbim.IDS.Validator.Core/IdsFacetBinderFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Xbim.Common.Step21;
+using Xbim.IDS.Validator.Core.Binders;
 using Xbim.IDS.Validator.Core.Interfaces;
 using Xbim.InformationSpecifications;
 
@@ -65,20 +66,24 @@ namespace Xbim.IDS.Validator.Core
         protected IDictionary<Type, Type> DefaultBinderMappings => _factoryOptions.DefaultBinderMappings;
         protected IDictionary<XbimSchemaVersion, IDictionary<Type, Type>> SchemaOverrideMappings => _factoryOptions.SchemaOverrideMappings;
 
-        public IFacetBinder Create(IFacet facet, XbimSchemaVersion schema)
+        public IFacetBinder Create(IFacet facet, IBinderContext context, XbimSchemaVersion schema)
         {
             if (TryGetBinderType(schema, facet, out Type type))
             {
-                return (IFacetBinder)_provider.GetRequiredService(type);
+                var binder = (IFacetBinder)_provider.GetRequiredService(type);
+                binder.Initialise(context);
+                return binder;
             }
             throw new NotImplementedException(facet.GetType().Name);
         }
 
-        public IFacetBinder<TFacet> Create<TFacet>(TFacet facet, XbimSchemaVersion schema) where TFacet : IFacet
+        public IFacetBinder<TFacet> Create<TFacet>(TFacet facet, IBinderContext context, XbimSchemaVersion schema) where TFacet : IFacet
         {
             if (TryGetBinderType(schema, facet, out Type type))
             {
-                return (IFacetBinder<TFacet>)_provider.GetRequiredService(type);
+                var binder = (IFacetBinder<TFacet>)_provider.GetRequiredService(type);
+                binder.Initialise(context);
+                return binder;
             }
             _logger.LogError("Did not find a binder registered for facet type {tyneName}", facet.GetType().Name);
             throw new NotImplementedException(facet.GetType().Name);

--- a/Xbim.IDS.Validator.Core/IdsModelBinder.cs
+++ b/Xbim.IDS.Validator.Core/IdsModelBinder.cs
@@ -26,10 +26,10 @@ namespace Xbim.IDS.Validator.Core
         public IIdsFacetBinderFactory FacetBinderFactory { get; }
 
 
-        public IdsModelBinder(IIdsFacetBinderFactory facetBinderFactory, BinderContext binderContext)
+        public IdsModelBinder(IIdsFacetBinderFactory facetBinderFactory)
         {
             FacetBinderFactory = facetBinderFactory;
-            this.binderContext = binderContext;
+            this.binderContext = binderContext = new BinderContext();
         }
 
 
@@ -145,7 +145,7 @@ namespace Xbim.IDS.Validator.Core
 
             foreach (var facet in requirement.Facets)
             {
-                var binder = FacetBinderFactory.Create(facet, Schema);
+                var binder = FacetBinderFactory.Create(facet, binderContext, Schema);
 
                 if(binder is ISupportOptions opts)
                 {
@@ -168,14 +168,14 @@ namespace Xbim.IDS.Validator.Core
         /// <exception cref="NotImplementedException"></exception>
         private Expression BindSelection(Expression baseExpression, IFacet facet)
         {
-            var binder = FacetBinderFactory.Create(facet, Schema);
+            var binder = FacetBinderFactory.Create(facet, binderContext, Schema);
             return binder.BindSelectionExpression(baseExpression, facet); 
            
         }
 
         private Expression BindFilters(Expression baseExpression, IFacet facet)
         {
-            var binder = FacetBinderFactory.Create(facet, Schema);
+            var binder = FacetBinderFactory.Create(facet, binderContext, Schema);
             return binder.BindWhereExpression(baseExpression, facet);
         }
 

--- a/Xbim.IDS.Validator.Extensions.COBie.Tests/COBieServicesTests.cs
+++ b/Xbim.IDS.Validator.Extensions.COBie.Tests/COBieServicesTests.cs
@@ -31,8 +31,9 @@ namespace Xbim.IDS.Validator.Extensions.COBie.Tests
             // Arrange
             var factory = provider.GetRequiredService<IIdsFacetBinderFactory>();
             var facet = (IFacet)Activator.CreateInstance(facetType);
+            var context = new BinderContext();
             // Act
-            var result = factory.Create(facet, Xbim.Common.Step21.XbimSchemaVersion.Cobie2X4);
+            var result = factory.Create(facet, context, Xbim.Common.Step21.XbimSchemaVersion.Cobie2X4);
             result.Should().NotBeNull().And.BeOfType(expectedType);
         }
 

--- a/Xbim.IDS.Validator.Extensions.COBie.Tests/CObieBinderTests.cs
+++ b/Xbim.IDS.Validator.Extensions.COBie.Tests/CObieBinderTests.cs
@@ -76,7 +76,8 @@ namespace Xbim.IDS.Validator.Extensions.COBie.Tests
         [Fact]
         public void CanQueryContacts()
         {
-            var binder = new IfcTypeFacetBinder(BinderContext, GetLogger<IfcTypeFacetBinder>()) { };
+            var binder = new IfcTypeFacetBinder(GetLogger<IfcTypeFacetBinder>()) { };
+            binder.Initialise(BinderContext);
             var types = new[] { typeof(CobieContact) };
             AssertIfcTypeFacetQuery(binder, "COBIECONTACT", 3, types);
         }
@@ -113,9 +114,10 @@ namespace Xbim.IDS.Validator.Extensions.COBie.Tests
                 AttributeValue = new ValueConstraint(attributeValue)
             };
 
-            var ifcbinder = new IfcTypeFacetBinder(BinderContext, IfcTypeLogger);
-
-            var attrbinder = new COBieAttributeFacetBinder(BinderContext, GetLogger<COBieAttributeFacetBinder>(), GetValueMapper());
+            var ifcbinder = new IfcTypeFacetBinder(IfcTypeLogger);
+            ifcbinder.Initialise(BinderContext);
+            var attrbinder = new COBieAttributeFacetBinder(GetLogger<COBieAttributeFacetBinder>(), GetValueMapper());
+            attrbinder.Initialise(BinderContext);
             attrbinder.SetOptions(new VerificationOptions { AllowDerivedAttributes = true, IncludeSubtypes = true }) ;
             // Act
             var expression = ifcbinder.BindSelectionExpression(query.InstancesExpression, ifcFacet);
@@ -136,7 +138,6 @@ namespace Xbim.IDS.Validator.Extensions.COBie.Tests
         [Theory]
         public void Cobie_Cannot_Query_By_Unsupported_Facets(Type facetType)
         {
-            SetContext();
             IfcTypeFacet ifcFacet = new IfcTypeFacet
             {
                 IfcType = new ValueConstraint("CobieComponent"),
@@ -145,8 +146,8 @@ namespace Xbim.IDS.Validator.Extensions.COBie.Tests
             var targetFacet = (IFacet)Activator.CreateInstance(facetType);
             PopulateDummyData(targetFacet);
 
-            var ifcbinder = facetBinderFactory.Create(ifcFacet, Model.SchemaVersion);
-            var targetBinder = facetBinderFactory.Create(targetFacet, Model.SchemaVersion);
+            var ifcbinder = facetBinderFactory.Create(ifcFacet, BinderContext, Model.SchemaVersion);
+            var targetBinder = facetBinderFactory.Create(targetFacet, BinderContext, Model.SchemaVersion);
 
             // Act
             var expression = ifcbinder.BindSelectionExpression(query.InstancesExpression, ifcFacet);
@@ -254,12 +255,6 @@ namespace Xbim.IDS.Validator.Extensions.COBie.Tests
             };
         }
 
-        
-        private void SetContext()
-        {
-            var context = provider.GetRequiredService<BinderContext>();
-            context.Model = BinderContext.Model;
-        }
 
         public override IModel Model
         {

--- a/Xbim.IDS.Validator.Extensions.COBie/Binders/COBieTableFacetBinder.cs
+++ b/Xbim.IDS.Validator.Extensions.COBie/Binders/COBieTableFacetBinder.cs
@@ -11,7 +11,7 @@ namespace Xbim.IDS.Validator.Extensions.COBie.Binders
     /// IFCPRODUCT broadly equivalent to COBIECOMPONENT, IFCACTOR => COBIECONTACT table</remarks>
     public class COBieTableFacetBinder : IfcTypeFacetBinder
     {
-        public COBieTableFacetBinder(BinderContext binderContext, ILogger<IfcTypeFacetBinder> logger) : base(binderContext, logger)
+        public COBieTableFacetBinder(ILogger<IfcTypeFacetBinder> logger) : base(logger)
         {
         }
         // Provided for future use/expansion. E.g. mapping frm IFC Types

--- a/Xbim.IDS.Validator.Extensions.COBie/Binders/CobieAttributeFacetBinder.cs
+++ b/Xbim.IDS.Validator.Extensions.COBie/Binders/CobieAttributeFacetBinder.cs
@@ -7,7 +7,7 @@ namespace Xbim.IDS.Validator.Extensions.COBie.Binders
     public class COBieAttributeFacetBinder: AttributeFacetBinder
     {
 
-        public COBieAttributeFacetBinder(BinderContext context, ILogger<COBieAttributeFacetBinder> logger, IValueMapper valueMapper) : base(context, logger, valueMapper)
+        public COBieAttributeFacetBinder(ILogger<COBieAttributeFacetBinder> logger, IValueMapper valueMapper) : base(logger, valueMapper)
         {
         }
 


### PR DESCRIPTION
Previously was DI Scoped (not transient) to allow an instance to be shared across binders, but this caused issues when multi-threading etc. whereby model instances could be shared across validation runs.

Lifetime of the BinderContext is now not a DI concern, and is controlled by the (Transient) IdsModelBinder instance