### PR TITLE
Fixed NRE issues in ElementType PDTs & added Spec skipping to skip over incompatible specs

### DIFF
--- a/Xbim.IDS.Validator.Common/IdsValidationResult.cs
+++ b/Xbim.IDS.Validator.Common/IdsValidationResult.cs
@@ -386,13 +386,17 @@ namespace Xbim.IDS.Validator.Core
         /// </summary>
         Fail,
         /// <summary>
-        /// A result could not be determined
+        /// A result has not been determined
         /// </summary>
         Inconclusive,
         /// <summary>
         /// A system or configuration failure prevented the specification from being checked
         /// </summary>
-        Error
+        Error,
+        /// <summary>
+        /// The specification was not run
+        /// </summary>
+        Skipped
     }
     
 

--- a/Xbim.IDS.Validator.Common/VerificationOptions.cs
+++ b/Xbim.IDS.Validator.Common/VerificationOptions.cs
@@ -49,6 +49,11 @@ namespace Xbim.IDS.Validator.Core
         /// Determines if the service will attempt to upgrade the IDS schema during the validation
         /// </summary>
         public bool PerformInPlaceSchemaUpgrade { get; set; } = true;
+
+        /// <summary>
+        /// Determines if verification will skip over specifications when the model schema is not compatible with the ifcVersion
+        /// </summary>
+        public bool SkipIncompatibleSpecification { get; set; } = false;
     }
 
     

--- a/Xbim.IDS.Validator.Core/Extensions/IfcEntityTypeExtensions.cs
+++ b/Xbim.IDS.Validator.Core/Extensions/IfcEntityTypeExtensions.cs
@@ -109,11 +109,11 @@ namespace Xbim.IDS.Validator.Core.Extensions
         private static string? GetObjectType(IIfcObjectDefinition entity)
         {
             if (entity is IIfcObject obj)
-                return obj.ObjectType?.Value.ToString();
+                return obj.ObjectType?.Value?.ToString();
             else if (entity is IIfcElementType type)
-                return type.ElementType?.Value.ToString();
+                return type.ElementType?.Value?.ToString();
             else if (entity is IIfcTypeProcess process)
-                return process.ProcessType?.Value.ToString();
+                return process.ProcessType?.Value?.ToString();
             else
                 return null;
         }


### PR DESCRIPTION
Added optional support for skipping incompatible specs. E.g. IFC4 specs against IFC2x3 models - Introduces new Outcome Validation status (ValidationStatus.Skipped)