### PR TITLE
Fix for missing IfcTypeObjects when selecting applicability via property facets

### DIFF
--- a/Xbim.IDS.Validator.Console/CliOptions.cs
+++ b/Xbim.IDS.Validator.Console/CliOptions.cs
@@ -109,7 +109,7 @@ namespace Xbim.IDS.Validator.Console
         public class DetokeniseCommand : BaseCommand
         {
             public static readonly Argument<FileInfo> IdsTemplateFileArgument = new Argument<FileInfo>("template", "An IDS template file (*.ids|*.xml)");
-            public static readonly Argument<FileInfo> IdsOutputFileArgument = new Argument<FileInfo>("template", "An IDS template file (*.ids|*.xml)");
+            public static readonly Argument<FileInfo> IdsOutputFileArgument = new Argument<FileInfo>("output", "An IDS template file (*.ids|*.xml)");
 
             public DetokeniseCommand(IServiceProvider provider) : base(provider, "detokenise", "Detokenise IDS files replacing tokens (e.g. {{ProjectCode}} ) in an IDS template with values of your choosing")
 

--- a/Xbim.IDS.Validator.Core.Tests/Binders/PsetFacetBinderTests.cs
+++ b/Xbim.IDS.Validator.Core.Tests/Binders/PsetFacetBinderTests.cs
@@ -27,13 +27,14 @@ namespace Xbim.IDS.Validator.Core.Tests.Binders
         //[InlineData("PSet_WallCommon", "LoadBearing", false, 5)]
         [InlineData("Pset_MemberCommon", "LoadBearing", true, 20)]
 
-        [InlineData("Other", "Category", "Furnit.*", 14, default(ConstraintType), default(ConstraintType), ConstraintType.Pattern)]
-        [InlineData("Other", "Categ.*", "Furnit.*", 14, default(ConstraintType), ConstraintType.Pattern, ConstraintType.Pattern)]
+        [InlineData("Other", "Category", "Furnit.*", 23, default(ConstraintType), default(ConstraintType), ConstraintType.Pattern)]
+        [InlineData("Other", "Categ.*", "Furnit.*", 23, default(ConstraintType), ConstraintType.Pattern, ConstraintType.Pattern)]
         [InlineData("Pset_PlateCommon", "ThermalTransmittance", "6.7069", 6)]
         [InlineData("Pset_Plate.*", "ThermalTransmittance", "6.7069", 6, ConstraintType.Pattern)]
         [InlineData("Constraints", "Sill Height", 900, 4, default(ConstraintType), default(ConstraintType), ConstraintType.Range)]
         [InlineData("Pset_MemberCommon", "Span", null, 20)]
         [InlineData("Pset_MemberCommon", "Span", "2043.570045136", 1)]
+        [InlineData("Other", "FrameDepth", "89", 1)]    // Pset on Type
         [InlineData("BaseQuantities", "Width", "1810", 5)]  // ElementQuantity  TODO: should factor in Unit Conversion?
         [Theory]
         public void Can_Query_By_Properties(string psetName, string propName, object propValue, int expectedCount,

--- a/Xbim.IDS.Validator.Core/Binders/PsetFacetBinder.cs
+++ b/Xbim.IDS.Validator.Core/Binders/PsetFacetBinder.cs
@@ -57,11 +57,11 @@ namespace Xbim.IDS.Validator.Core.Binders
 
 
             var expression = baseExpression;
-            // When an Ifc Type has not yet been specified, we start with the RelDefinesByProperties
+            // When an Ifc Type has not yet been specified, we start with the IIfcPropertySetDefinition
 
             if (expression.Type.IsInterface && typeof(IEntityCollection).IsAssignableFrom(expression.Type))
             {
-                expression = BindIfcExpressType(expression, Model.Metadata.GetExpressType(typeof(IIfcRelDefinesByProperties)), false);
+                expression = BindIfcExpressType(expression, Model.Metadata.GetExpressType(typeof(IIfcPropertySetDefinition)), true);
                 expression = BindPropertySelection(expression, psetFacet);
                 return expression;
             }
@@ -450,8 +450,8 @@ namespace Xbim.IDS.Validator.Core.Binders
 
             var facetExpr = Expression.Constant(psetFacet, typeof(IfcPropertyFacet));
             // Expression we're building
-            // var psetRelDefines = model.Instances.OfType<IIfcRelDefinesByProperties>();
-            // var entities = IfcExtensions.GetIfcObjectsWithProperties(psetRelDefines, facet);
+            // var psets = model.Instances.OfType<IIfcPropertySetDefinition>();
+            // var entities = IfcExtensions.GetIfcObjectsWithProperties(psets, facet);
 
             var propsMethod = ExpressionHelperMethods.EnumerableIfcObjectsWithProperties;
 
@@ -489,7 +489,7 @@ namespace Xbim.IDS.Validator.Core.Binders
             }
             else if (typeof(IIfcObjectDefinition).IsAssignableFrom(collectionType))
             {
-                // We could have a mixture of Objects and Types. (e.g. when starting IfcRelDefinesByProperties).
+                // We could have a mixture of Objects and Types. (e.g. when starting IIfcPropertySetDefinition).
                 // So have to cast and check objects and Types separately and concat the results.
                 // Use case, all elements with IsExternal=True which are also LoadBearing, could be a mix of Objects and Types
 

--- a/Xbim.IDS.Validator.Core/Extensions/IfcPropertiesExtensions.cs
+++ b/Xbim.IDS.Validator.Core/Extensions/IfcPropertiesExtensions.cs
@@ -14,19 +14,20 @@ namespace Xbim.IDS.Validator.Core.Extensions
         /// <summary>
         /// Gets all <see cref="IIfcObjectDefinition"/>s defined by the propertyset and name
         /// </summary>
-        /// <param name="relDefines"></param>
+        /// <param name="pset"></param>
         /// <param name="facet"></param>
         /// <returns></returns>
-        public static IEnumerable<IIfcObjectDefinition> GetIfcObjectsWithProperties(this IEnumerable<IIfcRelDefinesByProperties> relDefines,
+        public static IEnumerable<IIfcObjectDefinition> GetIfcObjectsWithProperties(this IEnumerable<IIfcPropertySetDefinition> pset,
             IfcPropertyFacet facet)
         {
-            if (relDefines is null)
+
+            if (pset is null)
             {
-                throw new ArgumentNullException(nameof(relDefines));
+                throw new ArgumentNullException(nameof(pset));
             }
 
-            return relDefines.FilterByPropertyFacet(facet)
-                    .SelectMany(r => r.RelatedObjects);
+            return pset.FilterByPropertyFacet(facet)
+                    .SelectMany(r => r.DefinesType.Union((IEnumerable<IIfcObjectDefinition>)r.DefinesOccurrence.SelectMany(o =>o.RelatedObjects)));
         }
 
         /// <summary>

--- a/Xbim.IDS.Validator.Core/Helpers/ExpressionHelperMethods.cs
+++ b/Xbim.IDS.Validator.Core/Helpers/ExpressionHelperMethods.cs
@@ -27,7 +27,7 @@ namespace Xbim.IDS.Validator.Core.Helpers
             m.GetParameters().Length == 1 &&
             m.ReturnType.GetGenericTypeDefinition() == typeof(IEnumerable<>));
         
-        private static MethodInfo _enumerableIfcObjectsWithPropertiesMethod = typeof(IfcPropertiesExtensions).GetMethod(nameof(IfcPropertiesExtensions.GetIfcObjectsWithProperties), new Type[] { typeof(IEnumerable<IIfcRelDefinesByProperties>), typeof(IfcPropertyFacet)});
+        private static MethodInfo _enumerableIfcObjectsWithPropertiesMethod = typeof(IfcPropertiesExtensions).GetMethod(nameof(IfcPropertiesExtensions.GetIfcObjectsWithProperties), new Type[] { typeof(IEnumerable<IIfcPropertySetDefinition>), typeof(IfcPropertyFacet)});
         private static MethodInfo _enumerableIfcAssociatesClassificationMethod = typeof(IfcClassificationExtensions).GetMethod(nameof(IfcClassificationExtensions.GetIfcObjectsUsingClassification), new Type[] { typeof(IEnumerable<IIfcRelAssociatesClassification>), typeof(IfcClassificationFacet) });
         private static MethodInfo _enumerableIfcMaterialSelectorMethod = typeof(IfcMaterialsExtensions).GetMethod(nameof(IfcMaterialsExtensions.GetIfcObjectsUsingMaterials), new Type[] { typeof(IEnumerable<IIfcRelAssociatesMaterial>), typeof(MaterialFacet) });
         private static MethodInfo _enumerableIfcPartofRelatedMethod = typeof(IfcRelationsExtensions).GetMethod(nameof(IfcRelationsExtensions.GetRelatedIfcObjects), new Type[] { typeof(IEnumerable<IIfcRelationship>), typeof(PartOfFacet) });


### PR DESCRIPTION
We were starting with  IfcRelDefinesByProperties which is only applicable to ObjectDefinitions. Now starts with the IfcPropertySets and picks up both Object occurrences and Types