### PR TITLE
Fix incorrectly cast applicability expressions

### DIFF
--- a/Xbim.IDS.Validator.Core.Tests/ModelSchemaHelperTests.cs
+++ b/Xbim.IDS.Validator.Core.Tests/ModelSchemaHelperTests.cs
@@ -1,0 +1,66 @@
+﻿using Xbim.IO.Memory;
+using Xbim.IDS.Validator.Core.Helpers;
+using System.Linq.Expressions;
+using FluentAssertions;
+using Xbim.Common;
+using Xbim.Ifc4.Interfaces;
+
+
+namespace Xbim.IDS.Validator.Core.Tests
+{
+    public class ModelSchemaHelperTests
+    {
+
+        [Fact]
+        public void CanGetAncestor()
+        {
+            var model = new MemoryModel(new Xbim.Ifc4.EntityFactoryIfc4x1());
+
+            Expression left = Expression.Constant(model.Instances.OfType<Ifc4.SharedBldgElements.IfcWall>());
+            Expression right = Expression.Constant(model.Instances.OfType<Ifc4.SharedBldgElements.IfcWindow>());
+            model.GetCommonAncestorType(left, right).Should().Be(typeof(Ifc4.ProductExtension.IfcBuildingElement));
+        }
+
+
+        [Fact]
+        public void CanGetAncestorObject()
+        {
+            var model = new MemoryModel(new Xbim.Ifc4.EntityFactoryIfc4x1());
+
+            Expression left = Expression.Constant(model.Instances.OfType<Xbim.Ifc4.Kernel.IfcActor>());
+            Expression right = Expression.Constant(model.Instances.OfType<Ifc4.SharedBldgElements.IfcWindow>());
+            model.GetCommonAncestorType(left, right).Should().Be(typeof(Ifc4.Kernel.IfcObject));
+        }
+
+        [Fact]
+        public void CanGetAncestorRooted()
+        {
+            var model = new MemoryModel(new Xbim.Ifc4.EntityFactoryIfc4x1());
+
+            Expression left = Expression.Constant(model.Instances.OfType<Ifc4.Kernel.IfcPropertySet>());
+            Expression right = Expression.Constant(model.Instances.OfType<Ifc4.SharedBldgElements.IfcWindow>());
+            model.GetCommonAncestorType(left, right).Should().Be(typeof(Ifc4.Kernel.IfcRoot));
+        }
+
+        [Fact]
+        public void CanGetAncestorUnRooted()
+        {
+            var model = new MemoryModel(new Xbim.Ifc4.EntityFactoryIfc4x1());
+
+            Expression left = Expression.Constant(model.Instances.OfType<Ifc4x3.MaterialResource.IfcMaterial>());
+            Expression right = Expression.Constant(model.Instances.OfType<Ifc4.SharedBldgElements.IfcWindow>());
+            model.GetCommonAncestorType(left, right).Should().Be(typeof(IPersistEntity));
+        }
+
+
+        [Fact]
+        public void CanGetAncestorByInterface()
+        {
+            var model = new MemoryModel(new Xbim.Ifc4.EntityFactoryIfc4x1());
+
+            Expression left = Expression.Constant(model.Instances.OfType<IIfcWall>());
+            Expression right = Expression.Constant(model.Instances.OfType<IIfcWindow>());
+            model.GetCommonAncestorType(left, right).Should().Be(typeof(Ifc4.ProductExtension.IfcBuildingElement));
+        }
+    }
+}

--- a/Xbim.IDS.Validator.Core/Binders/FacetBinderBase.cs
+++ b/Xbim.IDS.Validator.Core/Binders/FacetBinderBase.cs
@@ -313,8 +313,9 @@ namespace Xbim.IDS.Validator.Core.Binders
         {
 
             // e.g. Concat an IfcObjectDefinition + IfcTypeObject => IfcObject
-            Type highestCommonType = GetCommonAncestor(expression, right);
+            Type highestCommonType = Model.GetCommonAncestorType(expression, right);
             expression = BindCast(expression, highestCommonType);
+            right = BindCast(right, highestCommonType);
 
             expression = Expression.Call(null, ExpressionHelperMethods.EnumerableConcatGeneric.MakeGenericMethod(highestCommonType), expression, right);
             return expression;
@@ -331,29 +332,6 @@ namespace Xbim.IDS.Validator.Core.Binders
             return Expression.Call(null, ExpressionHelperMethods.EnumerableCastGeneric.MakeGenericMethod(type), expression);
         }
 
-        private Type GetCommonAncestor(Expression left, Expression right)
-        {
-            var leftType = TypeHelper.GetImplementedIEnumerableType(left.Type);
-            var rightType = TypeHelper.GetImplementedIEnumerableType(right.Type);
-
-            var ancestors = new HashSet<ExpressType>();
-            var express = Model.Metadata.ExpressType(leftType);
-            while(express != null)
-            {
-                ancestors.Add(express);
-                express = express.SuperType;
-            }
-            express = Model.Metadata.ExpressType(rightType);
-            while (express != null)
-            {
-                if(ancestors.Contains(express))
-                {
-                    return express.Type;
-                }
-                express = express.SuperType;
-            }
-            return typeof(IPersistEntity);
-        }
 
         protected IIfcValue? UnwrapQuantity(IIfcPhysicalQuantity quantity)
         {

--- a/Xbim.IDS.Validator.Core/Binders/IfcTypeFacetBinder.cs
+++ b/Xbim.IDS.Validator.Core/Binders/IfcTypeFacetBinder.cs
@@ -265,13 +265,14 @@ namespace Xbim.IDS.Validator.Core.Binders
 
             // Expression we're building:
             // var entities = model.Instances.OfType<IfcObjectDefinition>();
-            // var filteredresult = entities.WhereHasPredefinedType(e, facet));
+            // var filteredresult = entities.WhereHasPredefinedType(facet));
             // or
             // var filteredresult =  IfcEntityTypeExtensions.WhereHasPredefinedType(entities, facet);
+            var collectionType = TypeHelper.GetImplementedIEnumerableType(expression.Type);
 
             var typeFacetExpr = Expression.Constant(ifcFacet, typeof(IfcTypeFacet));
 
-            var propsMethod = ExpressionHelperMethods.EnumerableWhereIfcTypeHasMatchingPredefinedType;
+            var propsMethod = ExpressionHelperMethods.EnumerableWhereIfcTypeHasMatchingPredefinedType.MakeGenericMethod(collectionType);
 
             return Expression.Call(null, propsMethod, new[] { expression, typeFacetExpr });
 

--- a/Xbim.IDS.Validator.Core/Extensions/IfcEntityTypeExtensions.cs
+++ b/Xbim.IDS.Validator.Core/Extensions/IfcEntityTypeExtensions.cs
@@ -19,7 +19,7 @@ namespace Xbim.IDS.Validator.Core.Extensions
         /// <param name="objects"></param>
         /// <param name="facet"></param>
         /// <returns></returns>
-        public static IEnumerable<IIfcObjectDefinition> WhereHasPredefinedType(this IEnumerable<IIfcObjectDefinition> objects, IfcTypeFacet facet)
+        public static IEnumerable<T> WhereHasPredefinedType<T>(this IEnumerable<T> objects, IfcTypeFacet facet) where T: IIfcObjectDefinition
         {
             return objects.Where(o => MatchesPredefinedType(o, facet));
         }

--- a/Xbim.IDS.Validator.Core/Extensions/IfcPropertiesExtensions.cs
+++ b/Xbim.IDS.Validator.Core/Extensions/IfcPropertiesExtensions.cs
@@ -150,22 +150,22 @@ namespace Xbim.IDS.Validator.Core.Extensions
                         facet!.PropertyName?.IsSatisfiedBy(pe.Name.Value, true) == true &&
                         (
                             facet.PropertyValue?.HasAnyAcceptedValue() != true ||
-                            pe.EnumerationValues.Any(v => facet!.PropertyName?.IsSatisfiedBy(v.Value, true) == true)
+                            pe.EnumerationValues.Any(v => facet!.PropertyValue?.IsSatisfiedBy(v.Value, true) == true)
                         )).Any()
                         // List Values
                         || ps.HasProperties.OfType<IIfcPropertyListValue>().Where(pl =>
                         facet!.PropertyName?.IsSatisfiedBy(pl.Name.Value, true) == true &&
                         (
                             facet.PropertyValue?.HasAnyAcceptedValue() != true ||
-                            pl.ListValues.Any(v => facet!.PropertyName?.IsSatisfiedBy(v.Value, true) == true)
+                            pl.ListValues.Any(v => facet!.PropertyValue?.IsSatisfiedBy(v.Value, true) == true)
                         )).Any()
                         // Table Values
                         || ps.HasProperties.OfType<IIfcPropertyTableValue>().Where(ptv =>
                         facet!.PropertyName?.IsSatisfiedBy(ptv.Name.Value, true) == true &&
                         (
                             facet.PropertyValue?.HasAnyAcceptedValue() != true ||
-                            ptv.DefinedValues.Any(v => facet!.PropertyName?.IsSatisfiedBy(v.Value, true) == true) ||
-                            ptv.DefiningValues.Any(v => facet!.PropertyName?.IsSatisfiedBy(v.Value, true) == true)
+                            ptv.DefinedValues.Any(v => facet!.PropertyValue?.IsSatisfiedBy(v.Value, true) == true) ||
+                            ptv.DefiningValues.Any(v => facet!.PropertyValue?.IsSatisfiedBy(v.Value, true) == true)
                         )).Any()
                     ));
 

--- a/Xbim.IDS.Validator.Core/Globals.cs
+++ b/Xbim.IDS.Validator.Core/Globals.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Xbim.IDS.Validator.Core.Tests")]

--- a/Xbim.IDS.Validator.Core/Helpers/ExpressionHelperMethods.cs
+++ b/Xbim.IDS.Validator.Core/Helpers/ExpressionHelperMethods.cs
@@ -12,7 +12,6 @@ using Xbim.InformationSpecifications;
 
 namespace Xbim.IDS.Validator.Core.Helpers
 {
-
 #nullable disable
 
     internal class ExpressionHelperMethods
@@ -32,7 +31,7 @@ namespace Xbim.IDS.Validator.Core.Helpers
         private static MethodInfo _enumerableIfcMaterialSelectorMethod = typeof(IfcMaterialsExtensions).GetMethod(nameof(IfcMaterialsExtensions.GetIfcObjectsUsingMaterials), new Type[] { typeof(IEnumerable<IIfcRelAssociatesMaterial>), typeof(MaterialFacet) });
         private static MethodInfo _enumerableIfcPartofRelatedMethod = typeof(IfcRelationsExtensions).GetMethod(nameof(IfcRelationsExtensions.GetRelatedIfcObjects), new Type[] { typeof(IEnumerable<IIfcRelationship>), typeof(PartOfFacet) });
 
-        private static MethodInfo _enumerableWhereIfcEntityHasPredefinedTypeMethod = typeof(IfcEntityTypeExtensions).GetMethod(nameof(IfcEntityTypeExtensions.WhereHasPredefinedType), new Type[] { typeof(IEnumerable<IIfcObjectDefinition>), typeof(IfcTypeFacet) });
+        private static MethodInfo _enumerableWhereIfcEntityHasPredefinedTypeMethod = GenericMethodOf(_ => IfcEntityTypeExtensions.WhereHasPredefinedType<IIfcObjectDefinition>(default(IEnumerable<IIfcObjectDefinition>), default));
         private static MethodInfo _enumerableWhereObjAssociatedWithPropertyMethod = typeof(IfcPropertiesExtensions).GetMethod(nameof(IfcPropertiesExtensions.WhereAssociatedWithProperty), new Type[] { typeof(IEnumerable<IIfcObject>), typeof(IfcPropertyFacet) });
         private static MethodInfo _enumerableWhereTypeAssociatedWithPropertyMethod = typeof(IfcPropertiesExtensions).GetMethod(nameof(IfcPropertiesExtensions.WhereAssociatedWithProperty), new Type[] { typeof(IEnumerable<IIfcTypeObject>), typeof(IfcPropertyFacet) });
         private static MethodInfo _enumerableWhereAssociatedWithClassificationMethod = typeof(IfcClassificationExtensions).GetMethod(nameof(IfcClassificationExtensions.WhereAssociatedWithClassification), new Type[] { typeof(IEnumerable<IIfcObjectDefinition>), typeof(IfcClassificationFacet) });

--- a/Xbim.IDS.Validator.Core/Helpers/ModelSchemaHelper.cs
+++ b/Xbim.IDS.Validator.Core/Helpers/ModelSchemaHelper.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Xbim.Common.Metadata;
+using Xbim.Common;
+using Xbim.IDS.Validator.Core.Extensions;
+
+namespace Xbim.IDS.Validator.Core.Helpers
+{
+    public static class ModelSchemaHelper
+    {
+
+        /// <summary>
+        /// Gets the highest common IFC type for the two <see cref="IEnumerable{T}"/> <see cref="Expression"/>s
+        /// returning IPersistEntity when non exists (e.g. un-rooted types)
+        /// </summary>
+        /// <param name="model"></param>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
+        public static Type GetCommonAncestorType(this IModel model, Expression left, Expression right)
+        {
+            var leftType = TypeHelper.GetImplementedIEnumerableType(left.Type);
+
+            var rightType = TypeHelper.GetImplementedIEnumerableType(right.Type);
+
+            var ancestors = new HashSet<ExpressType>();
+            var express = model.Metadata.GetExpressType(leftType);
+            while (express != null)
+            {
+                ancestors.Add(express);
+                express = express.SuperType;
+            }
+            express = model.Metadata.GetExpressType(rightType);
+            while (express != null)
+            {
+                if (ancestors.Contains(express))
+                {
+                    return express.Type;
+                }
+                express = express.SuperType;
+            }
+            return typeof(IPersistEntity);
+        }
+    }
+}


### PR DESCRIPTION
Compound applicability queries were failing when an expression collection type was translated to IEnumerable of an _interface_ (for Example IIfcObjectDefinition rather than Ifc4...IfcObjectDefinition) when later concatenating queries. Case now handled in updated CommonAncester helper.

TODO: revise Applicability filters to be generic. e.g. `IfcMaterialsExtensions.WhereAssociatedWithMaterial()` should be generic.

Also fixed bug in filtering values in IfcPropertyEnumeratedValue, Lists and Table properties