### PR TITLE
Updating xids library

### DIFF
--- a/CodeGenerator/CodeGenerator.csproj
+++ b/CodeGenerator/CodeGenerator.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xbim.Essentials" Version="6.0.578" />
-    <PackageReference Include="Xbim.InformationSpecifications" Version="1.0.16" />
+    <PackageReference Include="Xbim.Essentials" Version="6.1.605" />
+    <PackageReference Include="Xbim.InformationSpecifications" Version="1.1.0-preview.14" />
   </ItemGroup>
 
 </Project>

--- a/Xbim.IDS.Validator.Common/Xbim.IDS.Validator.Common.csproj
+++ b/Xbim.IDS.Validator.Common/Xbim.IDS.Validator.Common.csproj
@@ -18,15 +18,14 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.10" />
-    <PackageReference Include="Xbim.InformationSpecifications" Version="1.0.16" />
+    <PackageReference Include="Xbim.InformationSpecifications" Version="1.1.0-preview.14" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetXbimV6)' != 'true'">
     <PackageReference Include="Xbim.Essentials" Version="5.1.341" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetXbimV6)' == 'true'">
-    <PackageReference Include="Xbim.Essentials" Version="6.0.578" />
+    <PackageReference Include="Xbim.Essentials" Version="6.1.605" />
   </ItemGroup>
 
 </Project>

--- a/Xbim.IDS.Validator.Core/Binders/AttributeFacetBinder.cs
+++ b/Xbim.IDS.Validator.Core/Binders/AttributeFacetBinder.cs
@@ -221,7 +221,7 @@ namespace Xbim.IDS.Validator.Core.Binders
                     {
                         // Unwrap the value from IfcValues etc.
                         attrvalue = MapValue(attrvalue, valueMapper);
-                        if (IsTypeAppropriateForConstraint(af.AttributeValue, attrvalue) && af.AttributeValue.ExpectationIsSatisifedBy(attrvalue, ctx, logger))
+                        if (IsTypeAppropriateForConstraint(af.AttributeValue, attrvalue) && af.AttributeValue.ExpectationIsSatisifedBy(attrvalue, ctx, true, logger))
                             result.MarkSatisified(ValidationMessage.Success(ctx, fn => fn.AttributeValue!, attrvalue, "Attribute value OK", item));
                         else
                         {

--- a/Xbim.IDS.Validator.Core/Binders/IfcClassificationFacetBinder.cs
+++ b/Xbim.IDS.Validator.Core/Binders/IfcClassificationFacetBinder.cs
@@ -202,7 +202,7 @@ namespace Xbim.IDS.Validator.Core.Binders
             if (!facet.ClassificationSystem.IsNullOrEmpty())
             {
                 var systemName = system.Name.Value?.ToString();
-                if(facet.ClassificationSystem.ExpectationIsSatisifedBy(systemName, ctx, logger, true) == true)
+                if(facet.ClassificationSystem.ExpectationIsSatisifedBy(systemName, ctx, false, logger) == true)
                 {
                     result.MarkSatisified(ValidationMessage.Success(ctx, fn => fn.ClassificationSystem!, systemName, "Classification System matched", system));
                     matched |= ClassificationSatisfiedBy.System;
@@ -244,7 +244,7 @@ namespace Xbim.IDS.Validator.Core.Binders
             foreach (var match in matches)
             {
                 var id = match.GetClassificationIdentifiers(logger)
-                    .FirstOrDefault(id => facet.Identification.ExpectationIsSatisifedBy(id, ctx, logger, true));
+                    .FirstOrDefault(id => facet.Identification.ExpectationIsSatisifedBy(id, ctx, false, logger));
                 if (id != null)
                 {
                     result.MarkSatisified(ValidationMessage.Success(ctx, fn => fn.Identification!, id, "Classification Identifier matched", match));

--- a/Xbim.IDS.Validator.Core/Binders/IfcTypeFacetBinder.cs
+++ b/Xbim.IDS.Validator.Core/Binders/IfcTypeFacetBinder.cs
@@ -124,7 +124,7 @@ namespace Xbim.IDS.Validator.Core.Binders
             while(currentEntityType != null)
             {
                 var actualName = currentEntityType?.Name.ToUpperInvariant();
-                if (f.IfcType.ExpectationIsSatisifedBy(actualName, ctx, logger))
+                if (f.IfcType.ExpectationIsSatisifedBy(actualName, ctx, false, logger))
                 {
                     result.MarkSatisified(ValidationMessage.Success(ctx, fn => fn.IfcType!, actualName, "Correct IFC Type", item));
                     break;
@@ -150,7 +150,7 @@ namespace Xbim.IDS.Validator.Core.Binders
                 var preDefValue = GetPredefinedType(item, out bool isUserDefined);
                 var satisifiedByAnyUserDefined = isUserDefined && f!.PredefinedType.IsSatisfiedBy("USERDEFINED");
 
-                if (f!.PredefinedType.ExpectationIsSatisifedBy(preDefValue, ctx, logger))
+                if (f!.PredefinedType.ExpectationIsSatisifedBy(preDefValue, ctx, true, logger))
                 {
                     result.MarkSatisified(ValidationMessage.Success(ctx, fn => fn.PredefinedType!, preDefValue, "Correct Predefined Type", item));
                 }

--- a/Xbim.IDS.Validator.Core/Binders/MaterialFacetBinder.cs
+++ b/Xbim.IDS.Validator.Core/Binders/MaterialFacetBinder.cs
@@ -122,7 +122,7 @@ namespace Xbim.IDS.Validator.Core.Binders
                     {
                         var materialName = material;
                     
-                        if (facet.Value.ExpectationIsSatisifedBy(materialName, ctx, logger, true))
+                        if (facet.Value.ExpectationIsSatisifedBy(materialName, ctx, false, logger))
                         {
                             result.MarkSatisified(ValidationMessage.Success(ctx, fn => fn.Value!, materialName, "Material matched", item));
                             success = true;

--- a/Xbim.IDS.Validator.Core/Binders/PsetFacetBinder.cs
+++ b/Xbim.IDS.Validator.Core/Binders/PsetFacetBinder.cs
@@ -320,7 +320,7 @@ namespace Xbim.IDS.Validator.Core.Binders
                     if (facet.PropertyValue != null)
                     {
                         attrvalue = MapValue(attrvalue, valueMapper);
-                        if (IsTypeAppropriateForConstraint(facet.PropertyValue, attrvalue) && facet.PropertyValue.ExpectationIsSatisifedBy(attrvalue, ctx, logger))
+                        if (IsTypeAppropriateForConstraint(facet.PropertyValue, attrvalue) && facet.PropertyValue.ExpectationIsSatisifedBy(attrvalue, ctx, true, logger))
                         {
                             result.MarkSatisified(ValidationMessage.Success(ctx, fn => fn.PropertyValue!, attrvalue, "Predefined Property value matched", predef));
                             success = true;
@@ -719,7 +719,7 @@ namespace Xbim.IDS.Validator.Core.Binders
         {
             if (pf.PropertyValue != null)
             {
-                if (IsTypeAppropriateForConstraint(pf.PropertyValue, value) && pf.PropertyValue.ExpectationIsSatisifedBy(value, ctx, logger))
+                if (IsTypeAppropriateForConstraint(pf.PropertyValue, value) && pf.PropertyValue.ExpectationIsSatisifedBy(value, ctx, true, logger))
                 {
                     return true;
                 }

--- a/Xbim.IDS.Validator.Core/Extensions/ValueConstraintExtensions.cs
+++ b/Xbim.IDS.Validator.Core/Extensions/ValueConstraintExtensions.cs
@@ -21,12 +21,12 @@ namespace Xbim.IDS.Validator.Core.Extensions
         /// <param name="constraint"></param>
         /// <param name="candidateValue"></param>
         /// <param name="ctx"></param>
-        /// <param name="logger"></param>
         /// <param name="caseSensitive"></param>
+        /// <param name="logger"></param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
         [return: NotNull]
-        public static bool ExpectationIsSatisifedBy<T>([NotNullWhen(true)]this ValueConstraint? constraint, object candidateValue, ValidationContext<T> ctx, ILogger? logger = null, bool caseSensitive = false) where T: IFacet
+        public static bool ExpectationIsSatisifedBy<T>([NotNullWhen(true)] this ValueConstraint? constraint, object candidateValue, ValidationContext<T> ctx, bool caseSensitive = true, ILogger? logger = null) where T: IFacet
         {
             var expectation = ctx.FacetCardinality switch
             {
@@ -36,7 +36,8 @@ namespace Xbim.IDS.Validator.Core.Extensions
                 
                 _ => throw new NotImplementedException()
             };
-            return constraint?.IsSatisfiedBy(candidateValue, caseSensitive, logger) == expectation;
+            // warning: the IsSatisfied expect a IgnoreCase parameter, as opposed to our caseSensitive, we negate it
+            return constraint?.IsSatisfiedBy(candidateValue, !caseSensitive, logger) == expectation; 
         }
 
         /// <summary>

--- a/Xbim.IDS.Validator.Core/IdsModelValidator.cs
+++ b/Xbim.IDS.Validator.Core/IdsModelValidator.cs
@@ -76,7 +76,7 @@ namespace Xbim.IDS.Validator.Core
                 if (verificationOptions.PermittedIdsAuditStatuses != VerificationOptions.AnyState)
                 {
                     // Validate the IDS
-                    Audit.Status schemaStatus = ValidateIdsSchema(idsSpec, userLogger);
+                    Audit.Status schemaStatus = ValidateIdsSchema(idsSpec, userLogger); // this step also performs a cleanup, changing capitalization of types
 
                     if (!verificationOptions.PermittedIdsAuditStatuses.HasFlag(schemaStatus))
                     {
@@ -213,7 +213,7 @@ namespace Xbim.IDS.Validator.Core
                 XDocument doc = detokeniser.ReplaceTokens(new FileInfo(idsFile), verificationOptions.RuntimeTokens);
                 return Xids.LoadBuildingSmartIDS(doc.Root, logger);
             }
-            return Xids.LoadBuildingSmartIDS(idsFile, logger);
+            return Xids.Load(new FileInfo(idsFile), logger);
         }
 
         private ValidationRequirement VerifyModelAgainstSpecification(Specification spec, IModel model, ILogger userLogger, CancellationToken token, VerificationOptions options)

--- a/Xbim.IDS.Validator.Tests.Common/IdsTestCaseRunner.cs
+++ b/Xbim.IDS.Validator.Tests.Common/IdsTestCaseRunner.cs
@@ -137,7 +137,7 @@ namespace Xbim.IDS.Validator.Tests.Common
                 logger.LogInformation("Verifying {schema} model {model}", schemaVersion, modelFile);
                 model = LoadModel(modelFile, schemaVersion, spotfix);
 
-                options ??= new VerificationOptions { PerformInPlaceSchemaUpgrade = false};
+                options ??= new VerificationOptions { PerformInPlaceSchemaUpgrade = false, PermittedIdsAuditStatuses = AuditStatus.IdsStructureWarning };
                 var validator = provider.GetRequiredService<IIdsModelValidator>();
 
                 var outcome = await validator.ValidateAgainstIdsAsync(model, idsFile, logger, null, options);


### PR DESCRIPTION
The new approach in xids performs a cleanup that changes the capitalization of entity types when reading an IDS.

This causes a problem with the tests that control that the case of IDS format.

Also changed the capitalization logic in ExpectationIsSatisifedBy to reduce a semantic risk between the `caseSensitive` and `ignoreCase` parameters. 